### PR TITLE
Bugfix endpoint path

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        go: [ '1.16.x' ]
+        go: [ '1.16.x', '1.17.x' ]
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Test Go Code
-        run: go test -short -race -covermode=atomic -coverprofile=coverage.txt ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.txt ./...
         env:
           KENALL_AUTHORIZATION_TOKEN: ${{ secrets.KENALL_AUTHORIZATION_TOKEN }}
       - name: Upload coverage to Codecov

--- a/kenall.go
+++ b/kenall.go
@@ -149,7 +149,7 @@ func (cli *Client) GetAddress(ctx context.Context, postalCode string) (*GetAddre
 		return nil, ErrInvalidArgument
 	}
 
-	const path = "/postalCode/"
+	const path = "/postalcode/"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cli.Endpoint+path+postalCode, nil)
 	if err != nil {

--- a/kenall_test.go
+++ b/kenall_test.go
@@ -282,7 +282,7 @@ func runTestingServer(t *testing.T) *httptest.Server {
 		}
 
 		switch path := r.URL.Path; {
-		case strings.HasPrefix(path, "/postalCode/"):
+		case strings.HasPrefix(path, "/postalcode/"):
 			handlePostalAPI(t, w, path)
 		case strings.HasPrefix(path, "/cities/"):
 			handleCityAPI(t, w, path)
@@ -296,21 +296,21 @@ func handlePostalAPI(t *testing.T, w http.ResponseWriter, path string) {
 	t.Helper()
 
 	switch path {
-	case "/postalCode/1008105":
+	case "/postalcode/1008105":
 		if _, err := w.Write(addressResponse); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-	case "/postalCode/4020000":
+	case "/postalcode/4020000":
 		w.WriteHeader(http.StatusPaymentRequired)
-	case "/postalCode/4030000":
+	case "/postalcode/4030000":
 		w.WriteHeader(http.StatusForbidden)
-	case "/postalCode/4050000":
+	case "/postalcode/4050000":
 		w.WriteHeader(http.StatusMethodNotAllowed)
-	case "/postalCode/5000000":
+	case "/postalcode/5000000":
 		w.WriteHeader(http.StatusInternalServerError)
-	case "/postalCode/5030000":
+	case "/postalcode/5030000":
 		w.WriteHeader(http.StatusServiceUnavailable)
-	case "/postalCode/0000001":
+	case "/postalcode/0000001":
 		if _, err := w.Write([]byte("wrong")); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}


### PR DESCRIPTION
## WHAT

- SSIA

## WHY

- Misspeling: `postalCode` -> `postalcode`