### PR TITLE
Update go stable versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
@@ -19,16 +19,16 @@ jobs:
           version: v1.49.0
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18.x', '1.19.x' ]
+        go: [ 'stable', 'oldstable' ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - run: go test -race -covermode=atomic -coverprofile=coverage.txt ./...
         env:
           KENALL_AUTHORIZATION_TOKEN: ${{ secrets.KENALL_AUTHORIZATION_TOKEN }}
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/osamingo/go-kenall/v2
 
-go 1.18
+go 1.19


### PR DESCRIPTION
## WHAT

- Support `Go 1.20`

## WHY

- Maintenance